### PR TITLE
Add hashbangs to build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_build
+_esy
+node_modules
+esy.lock

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -1,6 +1,8 @@
+#!/bin/bash
+
 cd _build
 
-# Automake gets brought in unnecessarily for the release package - 
+# Automake gets brought in unnecessarily for the release package -
 # force dependencies to be 'up-to-date' to skip automake...
 touch aclocal.m4
 touch Makefile.in
@@ -18,4 +20,3 @@ echo "**BUILD STARTED**"
 make
 echo "**BUILD COMPLETE**"
 make install
-

--- a/esy/configure-windows.sh
+++ b/esy/configure-windows.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 cd _build
 
 INSTALL_PATH="$(cygpath -u $cur__install)"

--- a/esy/configure.sh
+++ b/esy/configure.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 cd _build
 ./configure --prefix=$cur__install

--- a/esy/prep.sh
+++ b/esy/prep.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 cp -rp harfbuzz-2.6.4 _build
 
 cd _build

--- a/esy/test.sh
+++ b/esy/test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 INCLUDE=$cur__install/include/harfbuzz
 


### PR DESCRIPTION
This package doesn't build on Ubuntu because there are no hashbangs in the files, alternatively I can update the build commands to be of the form `["bash", "./esy/prep.sh"]` which also works fine. I figured this was less intrusive since it's just a comment though